### PR TITLE
Fix incorrect property name in bulk faker description

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Customer.faker({
 })
 
 Customer.bulkFaker({
-    global: {
+    globals: {
         name: 'Every One Gets this Name'
     },
     individuals: [


### PR DESCRIPTION
Method expects `globals`.
