### PR TITLE
Correctly throw error when argument passed is not a function

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -17,7 +17,11 @@ module.exports.FakerMixin = class FakerMixin {
   }
   getFakerFunc (key) {
     try {
-      return key.split('.').reduce((a, b) => a[b], this.faker)
+      let method = key.split('.').reduce((a, b) => a[b], this.faker)
+      if(typeof method !== 'function') {
+        throw new Error('Not a function')
+      }
+      return method;
     } catch (err) {
       throw new Error(`${key} does not exist on faker`)
     }

--- a/tests/faker.spec.js
+++ b/tests/faker.spec.js
@@ -72,3 +72,9 @@ describe('bulk faker without arguments', () => {
     assert.lengthOf(d, 0)
   })
 })
+describe('invalid arguments', () => {
+  it('should should throw an error if the argument passed is not a function', () => {
+    let a = new FakerMixin(MockModel, { company: { name: false } }, { name: 'company.name' })
+    expect(a.init.bind(a)).to.throw('company.name does not exist on faker')
+  })
+});


### PR DESCRIPTION
Closes #4 

